### PR TITLE
Replace array_intersect_assoc with array_intersect

### DIFF
--- a/relatedpages.php
+++ b/relatedpages.php
@@ -139,7 +139,7 @@ class RelatedPagesPlugin extends Plugin
 
                             if (isset($item_taxonomies[$taxonomy])) {
                                 $item_taxonomy = $item_taxonomies[$taxonomy];
-                                $count = count(array_intersect_assoc($page_taxonomy, $item_taxonomy));
+                                $count = count(array_intersect($page_taxonomy, $item_taxonomy));
 
                                 if ($count > 0) {
                                     if (array_key_exists($count, $score_scale)) {


### PR DESCRIPTION
In my case, I use the default category taxonomy but I had to articles where the 2 categories where in different order. As _assoc uses the array key to compare, it did not match them, so array_intersect seems more appropriate to bypass the order of the taxonomy and match them in any order.