### PR TITLE
Allow multiple taxonomies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ explicit_pages:
     score: 100                  # score (0 - 100) to give explicit pages
 taxonomy_match:                 # taxonomy type matching
     taxonomy: tag               # which taxonomy type to use
+#   taxonomy: [category, tag]   # multiple taxonomies example
     taxonomy_taxonomy:
         process: true           # true|false to enable taxonomy to taxonomy matching
         score_scale:            # scores for number of matches

--- a/relatedpages.php
+++ b/relatedpages.php
@@ -129,49 +129,75 @@ class RelatedPagesPlugin extends Plugin
                     // count taxonomy to taxonomy matches
                     if ($config['taxonomy_match']['taxonomy_taxonomy']['process']) {
 
-                        $taxonomy = $config['taxonomy_match']['taxonomy'];
+                        // Check for multiple taxonomies.
+                        $taxonomy_list = $config['taxonomy_match']['taxonomy'];
+                        // Support the single value by converting it to array.
+                        if (!is_array ($taxonomy_list)) {
+                            $taxonomy_list = array($taxonomy_list);
+                        }
                         $score_scale = $config['taxonomy_match']['taxonomy_taxonomy']['score_scale'];
+                        
+                        $score = 0;
+                        $has_matches = false;
+                        foreach ($taxonomy_list as $taxonomy) {
+                            if (isset($page_taxonomies[$taxonomy])) {
+                                $page_taxonomy = $page_taxonomies[$taxonomy];
+                                $item_taxonomies = $item->taxonomy();
 
+                                if (isset($item_taxonomies[$taxonomy])) {
+                                    $item_taxonomy = $item_taxonomies[$taxonomy];
+                                    $count = count(array_intersect($page_taxonomy, $item_taxonomy));
 
-                        if (isset($page_taxonomies[$taxonomy])) {
-                            $page_taxonomy = $page_taxonomies[$taxonomy];
-                            $item_taxonomies = $item->taxonomy();
-
-                            if (isset($item_taxonomies[$taxonomy])) {
-                                $item_taxonomy = $item_taxonomies[$taxonomy];
-                                $count = count(array_intersect($page_taxonomy, $item_taxonomy));
-
-                                if ($count > 0) {
-                                    if (array_key_exists($count, $score_scale)) {
-                                        $score = $score_scale[$count];
-                                    } else {
-                                        $score = max(array_keys($score_scale));
+                                    if ($count > 0) {
+                                        if (array_key_exists($count, $score_scale)) {
+                                            $score += $score_scale[$count];
+                                        } else {
+                                            $score += max(array_keys($score_scale));
+                                        }
+                                        
+                                        $has_matches = true;
                                     }
-                                    $taxonomy_taxonomy_matches[$item->path()] = $score;
                                 }
                             }
+                        }
+                        
+                        if ($has_matches) {
+                            $taxonomy_taxonomy_matches[$item->path()] = $score;
                         }
                     }
 
                     // count taxonomy to content matches
                     if ($config['taxonomy_match']['taxonomy_content']['process']) {
 
-                        $taxonomy = $config['taxonomy_match']['taxonomy'];
+                        // Check for multiple taxonomies.
+                        $taxonomy_list = $config['taxonomy_match']['taxonomy'];
+                        // Support the single value by converting it to array.
+                        if (!is_array ($taxonomy_list)) {
+                            $taxonomy_list = array($taxonomy_list);
+                        }
                         $score_scale = $config['taxonomy_match']['taxonomy_content']['score_scale'];
 
+                        $score = 0;
+                        $has_matches = false;
+                        foreach ($taxonomy_list as $taxonomy) {
+                            if (isset($page_taxonomies[$taxonomy])) {
+                                $page_taxonomy = $page_taxonomies[$taxonomy];
+                                $count = $this->substringCountArray($item->title().' '.$item->rawMarkdown(), $page_taxonomy);
 
-                        if (isset($page_taxonomies[$taxonomy])) {
-                            $page_taxonomy = $page_taxonomies[$taxonomy];
-                            $count = $this->substringCountArray($item->title().' '.$item->rawMarkdown(), $page_taxonomy);
-
-                            if ($count > 0) {
-                                if (array_key_exists($count, $score_scale)) {
-                                    $score = $score_scale[$count];
-                                } else {
-                                    $score = max(array_keys($score_scale));
+                                if ($count > 0) {
+                                    if (array_key_exists($count, $score_scale)) {
+                                        $score += $score_scale[$count];
+                                    } else {
+                                        $score += max(array_keys($score_scale));
+                                    }
+                                    
+                                    $has_matches = true;
                                 }
-                                $taxonomy_content_matches[$item->path()] = $score;
                             }
+                        }
+                        
+                        if ($has_matches) {
+                            $taxonomy_content_matches[$item->path()] = $score;
                         }
                     }
 


### PR DESCRIPTION
Hello!
This PR proposes to allow multiple taxonomies to be used for generating score (sum the scores for all matched taxonomies). The diff looks kinda messy, though, because I moved some code inside the loop...
In my particular use case I need to show related pages using multiple taxonomies to migrate from a certain blogging CMS to Grav. :) And I thought it might be useful to someone else.
Ideally, each taxonomy should have its own scale, but I thought it was too much change.