### PR TITLE
Missing Quotes?

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -58,7 +58,7 @@ form:
       yaml: true
       label: PLUGIN_REL_PAGES.ITEMS
       help: PLUGIN_REL_PAGES.ITEMS_HELP
-      default: '@page: /blog'
+      default: '@page': '/blog'
 
     filter.order.by:
       type: select


### PR DESCRIPTION
I'm not sure, but I noticed that the collection definition as set by default might not work as it lacks the single quote wrapping the /blog slug.