### PR TITLE
Add an exclude types filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ score_threshold: 20             # minimum score needed to show up in the list
 filter:                         # filter a configurable collection of pages to compare
     items:
         @page: /blog            # supports @self, @page, and @taxonomy collections
+    excluded_types:             # exclude certain type of content if the header contains the type of one in the list
+        - quote
+        - video
     order:
         by: date                # order type by default
         dir: desc               # order direction

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -61,7 +61,14 @@ form:
       type: multilevel
       label: PLUGIN_REL_PAGES.ITEMS
       value_only: true
-      validate: 
+      validate:
+        type: array
+
+    filter.excluded_types:
+      type: array
+      label: PLUGIN_REL_PAGES.EXCLUDED_TYPES
+      value_only: true
+      validate:
         type: array
 
     filter.order.by:

--- a/languages.yaml
+++ b/languages.yaml
@@ -28,7 +28,8 @@ en:
     ADVANCED: Advanced
     TAXONOMY_SCORE_SCALE: Taxonomy-taxonomy score scale
     CONTENT_SCORE_SCALE: Taxonomy-content score scale
-    
+    EXCLUDED_TYPES: Page types to exclude from results
+
 de:
   PLUGIN_REL_PAGES:
     PLUGIN_STATUS: Plugin-Status
@@ -60,7 +61,8 @@ de:
     ADVANCED: Erweitert
     TAXONOMY_SCORE_SCALE: Taxonomie-Taxonomie Bewertungsskala
     CONTENT_SCORE_SCALE: Taxonomie-Inhalt Bewertungsskala
-    
+    EXCLUDED_TYPES: Seitentypen, die von den Ergebnissen ausgeschlossen werden sollen
+
 fr:
   PLUGIN_REL_PAGES:
     BASICS: Réglages de base
@@ -91,7 +93,8 @@ fr:
     ADVANCED: Avancés
     TAXONOMY_SCORE_SCALE: Taxonomie-niveau de score de taxonomie
     CONTENT_SCORE_SCALE: Taxonomie-niveau de score de contenu
-    
+    EXCLUDED_TYPES: Types de pages à exclure des résultats
+
 nl:
   PLUGIN_REL_PAGES:
     BASICS: Basisinstellingen
@@ -122,6 +125,7 @@ nl:
     ADVANCED: Geavanceerd
     TAXONOMY_SCORE_SCALE: Taxonomie-taxonomie score schaal
     CONTENT_SCORE_SCALE: Taxonomie-inhoud score schaal
+    EXCLUDED_TYPES: Paginatypen die moeten worden uitgesloten van resultaten
 
 ro:
  PLUGIN_REL_PAGES:
@@ -133,26 +137,27 @@ ro:
     SHOW_SCORE: Arată scorul
     SHOW_SCORE_HELP: Comutați pentru afișarea scorurilor
     ITEMS: Articole
-    ITEMS_HELP: Acceptă colecții bazate pe `@self`, `@page` și `@taxonomy` 
+    ITEMS_HELP: Acceptă colecții bazate pe `@self`, `@page` și `@taxonomy`
     PAGE_IN_FILTER: Filtru 'in' pagină
     PAGE_IN_FILTER_HELP: Activează dacă pagina curentă trebuie să fie în colecția filtrată
     EXPLICIT_PROCESS: Procesează anumite pagini specifice
     EXPLICIT_PROCESS_HELP: Activează pentru procesarea anumitor pagini specifice
-    EXPLICIT_SCORE: Scorul paginilor specifice 
+    EXPLICIT_SCORE: Scorul paginilor specifice
     EXPLICIT_SCORE_HELP: Un scor între (0 - 100) pentru a da unor pagini specifice greutate
-    TAXONOMY_MATCH: Potrivire după Taxonomie 
+    TAXONOMY_MATCH: Potrivire după Taxonomie
     TAXONOMY: Taxonomie
-    TAXONOMY_HELP: Ce fel de taxonomie să fie folosită la potrivirea paginilor 
+    TAXONOMY_HELP: Ce fel de taxonomie să fie folosită la potrivirea paginilor
     TAXONOMY_TAXONOMY_PROCESS: Taxonomie-taxonomie
     TAXONOMY_TAXONOMY_PROCESS_HELP: Activeazā potrivirea între taxonomii
     TAXONOMY_CONTENT_PROCESS: Taxonomie-conținut
-    TAXONOMY_CONTENT_PROCESS_HELP: Activează potrivirea după taxonomie - conținut 
-    CONTENT_MATCH: Potrivirea după conținut 
+    TAXONOMY_CONTENT_PROCESS_HELP: Activează potrivirea după taxonomie - conținut
+    CONTENT_MATCH: Potrivirea după conținut
     CONTENT_PROCESS: Conținut-conținut
     CONTENT_PROCESS_HELP: "Activează pentru potrivire după conținut (Notă: dezactivați dacă aveți conținut mult)"
     ADVANCED: Avansat
     TAXONOMY_SCORE_SCALE: Scorul scalei Taxonomie-taxonomie
     CONTENT_SCORE_SCALE: Scorul scalei Taxonomie-conținut
+    EXCLUDED_TYPES: tipuri de pagini de exclus din rezultate
 
 es:
   PLUGIN_REL_PAGES:
@@ -184,4 +189,4 @@ es:
     ADVANCED: Avanzado
     TAXONOMY_SCORE_SCALE: Escala de puntuación Taxonomía-taxonomía
     CONTENT_SCORE_SCALE: Escala de puntuación Taxonomía-contenido
-    
+    EXCLUDED_TYPES: tipos de página para excluir de los resultados

--- a/relatedpages.php
+++ b/relatedpages.php
@@ -76,7 +76,6 @@ class RelatedPagesPlugin extends Plugin
 
         $cache_id = md5('relatedpages' . $page->path() . $cache->getKey());
         $this->related_pages = $cache->fetch($cache_id);
-        $this->related_pages = false;
 
         if ($this->related_pages === false) {
 

--- a/relatedpages.php
+++ b/relatedpages.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Grav\Plugin;
 
+use Grav\Common\Cache;
+use Grav\Common\Config\Config;
+use Grav\Common\Debugger;
 use Grav\Common\Page\Interfaces\PageInterface;
-use \Grav\Common\Plugin;
-use \Grav\Common\Cache;
-use \Grav\Common\Debugger;
-use \Grav\Common\Config\Config;
-use \Grav\Common\Page\Pages;
+use Grav\Common\Page\Pages;
+use Grav\Common\Plugin;
 
 class RelatedPagesPlugin extends Plugin
 {
@@ -73,13 +74,27 @@ class RelatedPagesPlugin extends Plugin
             'onTwigSiteVariables' => ['onTwigSiteVariables', 0]
         ]);
 
-        $cache_id = md5('relatedpages'.$page->path().$cache->getKey());
+        $cache_id = md5('relatedpages' . $page->path() . $cache->getKey());
         $this->related_pages = $cache->fetch($cache_id);
+        $this->related_pages = false;
 
         if ($this->related_pages === false) {
 
             // get all the pages
             $collection = $page->collection($config['filter']);
+
+            //If the header of a page has a type and it is included in the excluded types remove it from the collection
+            foreach ($collection as $pageKey) {
+                $header = $pageKey->header();
+                if (
+                    property_exists($header, 'type') &&
+                    array_key_exists('filter', $config) &&
+                    array_key_exists('excluded_types', $config['filter']) &&
+                    in_array($header->type, $config['filter']['excluded_types'])
+                ) {
+                    $collection->remove($pageKey);
+                }
+            }
 
             // perform check if page must be in filter values
             if ($config['page_in_filter'] && !\in_array($page, iterator_to_array($collection), true)) {
@@ -129,11 +144,11 @@ class RelatedPagesPlugin extends Plugin
                         // Check for multiple taxonomies.
                         $taxonomy_list = $config['taxonomy_match']['taxonomy'];
                         // Support the single value by converting it to array.
-                        if (!\is_array ($taxonomy_list)) {
+                        if (!\is_array($taxonomy_list)) {
                             $taxonomy_list = array($taxonomy_list);
                         }
                         $score_scale = $config['taxonomy_match']['taxonomy_taxonomy']['score_scale'];
-                        
+
                         $score = 0;
                         $has_matches = false;
                         foreach ($taxonomy_list as $taxonomy) {
@@ -151,13 +166,13 @@ class RelatedPagesPlugin extends Plugin
                                         } else {
                                             $score += max(array_keys($score_scale));
                                         }
-                                        
+
                                         $has_matches = true;
                                     }
                                 }
                             }
                         }
-                        
+
                         if ($has_matches) {
                             $taxonomy_taxonomy_matches[$item->path()] = $score;
                         }
@@ -169,7 +184,7 @@ class RelatedPagesPlugin extends Plugin
                         // Check for multiple taxonomies.
                         $taxonomy_list = $config['taxonomy_match']['taxonomy'];
                         // Support the single value by converting it to array.
-                        if (!is_array ($taxonomy_list)) {
+                        if (!is_array($taxonomy_list)) {
                             $taxonomy_list = array($taxonomy_list);
                         }
                         $score_scale = $config['taxonomy_match']['taxonomy_content']['score_scale'];
@@ -179,7 +194,7 @@ class RelatedPagesPlugin extends Plugin
                         foreach ($taxonomy_list as $taxonomy) {
                             if (isset($page_taxonomies[$taxonomy])) {
                                 $page_taxonomy = $page_taxonomies[$taxonomy];
-                                $count = $this->substringCountArray($item->title().' '.$item->rawMarkdown(), $page_taxonomy);
+                                $count = $this->substringCountArray($item->title() . ' ' . $item->rawMarkdown(), $page_taxonomy);
 
                                 if ($count > 0) {
                                     if (array_key_exists($count, $score_scale)) {
@@ -187,12 +202,12 @@ class RelatedPagesPlugin extends Plugin
                                     } else {
                                         $score += max(array_keys($score_scale));
                                     }
-                                    
+
                                     $has_matches = true;
                                 }
                             }
                         }
-                        
+
                         if ($has_matches) {
                             $taxonomy_content_matches[$item->path()] = $score;
                         }
@@ -243,7 +258,7 @@ class RelatedPagesPlugin extends Plugin
 
     protected function mergeRelatedPages(array $pages)
     {
-        foreach ((array) $pages as $path => $score) {
+        foreach ((array)$pages as $path => $score) {
             $page_exists = array_key_exists($path, $this->related_pages);
             if ($score > $this->config['score_threshold'] &&
                 (!$page_exists || ($page_exists && $score > $this->related_pages[$path]))) {

--- a/relatedpages.yaml
+++ b/relatedpages.yaml
@@ -4,7 +4,10 @@ show_score: true                # toggle to determine if scores should be displa
 score_threshold: 20             # minimum score needed to show up in the list
 filter:                         # filter a configurable collection of pages to compare
     items:
-        '@page': /blog            # supports @self, @page, and @taxonomy collections
+        '@page': /blog          # supports @self, @page, and @taxonomy collections
+    excluded_types:             # exclude certain type of content if the header contains the type of one in the list
+        - quote
+        - video
     order:
         by: date                # order type by default
         dir: desc               # order direction


### PR DESCRIPTION
Hey, Thanks for this plugin it is great ! 
In my case I have some 'types' of pages that I do not need nor want in the related pages. I have added some config so you can add 'excluded_types' in your filter settings. If one of your pages has a 'type' included in this filter list in his header it will be removed from the possible results.

I hope this can be usefull for someone else.